### PR TITLE
Update index.md

### DIFF
--- a/content/community/index.md
+++ b/content/community/index.md
@@ -15,7 +15,7 @@ The CSSU enjoys the support of partner course unions and the Department of Compu
 
 {{< profilePic/profilePic  bold=true name="ASSU"  position="Arts & Science Student Union" personal="https://assu.ca/wp" linkedin="https://www.linkedin.com/company/uoft-assu" facebook="https://www.facebook.com/assu.uoft" profile_pic="/images/rcgs/assu.jpg" >}}
 
-{{< profilePic/profilePic  bold=true name="BCBSU"  position="Bioinformatics & Computational Biology Student Union" personal="https://bcbuoft.github.io/bcbuoft" linkedin="https://linkedin.com/company/computer-science-student-union" facebook="https://www.facebook.com/BCBSU.UofT" github="https://github.com/bcbuoft" profile_pic="/images/rcgs/bcb.png" >}}
+{{< profilePic/profilePic  bold=true name="BCBSU"  position="Bioinformatics & Computational Biology Student Union" personal="https://bcbuoft.github.io/bcbuoft" facebook="https://www.facebook.com/BCBSU.UofT" github="https://github.com/bcbuoft" profile_pic="/images/rcgs/bcb.png" >}}
 
 {{< profilePic/profilePic  bold=true name="CSSU"  position="Computer Science Student Union" personal="https://cssu.ca" linkedin="https://linkedin.com/company/computer-science-student-union" facebook="https://facebook.com/UofTCSSU" github="https://github.com/cssu">}}
 
@@ -31,28 +31,27 @@ Recognized campus groups (RCGs) are student groups ("clubs") recognized by [**UL
 
 {{< profilePic/profilePicContainer >}}
 
-{{< profilePic/profilePic  bold=true name="ACCS"  position="Association of Chinese Computer Students" profile_pic="/images/rcgs/accs.jpg">}}
 {{< profilePic/profilePic  bold=true name="UTADA"  position="U of T Application Development Association" personal="https://uoftada.com" linkedin="https://www.linkedin.com/company/university-of-toronto-application-development-association" facebook="https://www.facebook.com/uoftada/" profile_pic="/images/rcgs/utada.png">}}
 {{< profilePic/profilePic bold=true name="UofT AI"  position="U of T Undergraduate Artificial Intelligence Group"  personal="https://uoft.ai" linkedin="https://www.linkedin.com/company/uaig-uoft/"  facebook="https://www.facebook.com/uoftaigroup"  github="https://github.com/uoftai" profile_pic="/images/rcgs/uoft_ai.jfif">}}
 {{< profilePic/profilePic  bold=true name="aUToronto"  position="U of T Self-Driving Car Team" personal="https://www.autodrive.utoronto.ca" linkedin="https://www.linkedin.com/company/autoronto/" facebook="https://www.facebook.com/aUToronto/" profile_pic="/images/rcgs/autoronto.jpg">}}
 {{< profilePic/profilePic bold=true name="UofT Blueprint" personal="https://uoftblueprint.org/" linkedin="https://www.linkedin.com/company/uoftblueprint/"  facebook="https://www.facebook.com/uoftblueprint" profile_pic="/images/rcgs/uoftblueprint.png">}}
 {{< profilePic/profilePic  bold=true name="UofTCTF"  position="U of T Capture the Flag" personal="https://uoftctf.org/" github="https://github.com/UofTCTF" profile_pic="/images/rcgs/uoftctf.png">}}
 {{< profilePic/profilePic  bold=true name="UTCG"  position="U of T Computer Graphics" personal="https://utcg.club" linkedin="https://www.linkedin.com/company/university-of-toronto-computer-graphics-club" facebook="https://www.facebook.com/UTComputerGraphics" github="https://github.com/UTCG"  profile_pic="/images/rcgs/utcg.png">}}
-{{< profilePic/profilePic  bold=true name="CSSA"  position="UofT Cybersecurity Student Association" facebook="https://www.facebook.com/uoftcssa" profile_pic="/images/rcgs/cssa.jpg">}}
-{{< profilePic/profilePic  bold=true name="DST"  position="Data Science Toronto" personal="https://datasciencetoronto.wixsite.com/home" linkedin="https://www.linkedin.com/company/data-science-toronto" facebook="https://www.facebook.com/uoftdatasciencetoronto" github="https://github.com/UTMIST" profile_pic="/images/rcgs/dst.png">}}
+{{< profilePic/profilePic  bold=true name="CSSA"  position="UofT Cybersecurity Student Association" personal="https://cssa.sa.utoronto.ca/" linkedin="https://www.linkedin.com/company/uoftcssa/about/" facebook="https://www.facebook.com/uoftcssa" profile_pic="/images/rcgs/cssa.jpg">}}
+{{< profilePic/profilePic  bold=true name="DST"  position="Data Science Toronto" personal="https://datasciencetoronto.wixsite.com/home" linkedin="https://www.linkedin.com/company/data-science-toronto" facebook="https://www.facebook.com/uoftdatasciencetoronto" profile_pic="/images/rcgs/dst.png">}}
 {{< profilePic/profilePic  bold=true name="DSC UTSG"  position="Developer Student Clubs" personal="https://sites.google.com/view/dscutsg/home" linkedin="https://www.linkedin.com/company/dscutsg" facebook="https://www.facebook.com/Developer-Student-Club-University-of-Toronto-105026347541094" github="https://github.com/Developer-Student-Club-UofT"  profile_pic="/images/rcgs/dsc_utsg.png">}}
 {{< profilePic/profilePic  bold=true name="UTGDDC"  position="U of T Game Design & Development Club" personal="http://www.utgddc.com" linkedin="https://www.linkedin.com/company/u-of-t-game-design-design-and-development-club" facebook="https://www.facebook.com/utGDDC" profile_pic="/images/rcgs/gddc.jpg">}}
 {{< profilePic/profilePic  bold=true name="UofT Hacks" personal="https://uofthacks.com/" linkedin="https://www.linkedin.com/company/uoftorontohacks" facebook="https://www.facebook.com/UoftHacksT" profile_pic="/images/rcgs/uofthacks.png">}}
 {{< profilePic/profilePic  bold=true name="HAKCS" position="Association of Korean Computer Science Students" personal="https://discord.gg/pkZqwzTMTw" facebook="https://www.facebook.com/groups/2264828079" profile_pic="/images/rcgs/hakcs.png">}}
 {{< profilePic/profilePic  bold=true name="UTMIST"  position="U of T Machine Intelligence Student Team" personal="https://utmist.gitlab.io" linkedin="https://linkedin.com/company/utmist" facebook="https://facebook.com/UofT.MIST" github="https://github.com/UTMIST" gitlab="https://gitlab.com/UTMIST" profile_pic="/images/rcgs/utmist.png">}}
 {{< profilePic/profilePic  bold=true name="NeuroTechUofT"  personal="https://neurotechuoft.com/index.html" linkedin="https://www.linkedin.com/company/neurotechuoft" facebook="https://www.facebook.com/groups/neurotechUofT" github="https://github.com/neurotechuoft" profile_pic="/images/rcgs/neurotechuoft.png">}}
-{{< profilePic/profilePic  bold=true name="UTQCC"  position="U of T Quantum Computing Club" linkedin="https://linkedin.com/company/utmist" facebook="https://www.facebook.com/UTQCC" profile_pic="/images/rcgs/utqcc.png">}}
+{{< profilePic/profilePic  bold=true name="UTQC"  position="U of T Quantum Computing Club" personal="https://sop.utoronto.ca/group/quantum-computing-club/" facebook="https://www.facebook.com/UTQCC" profile_pic="/images/rcgs/utqcc.png">}}
 {{< profilePic/profilePic  bold=true name="UTRA"  position="UofT Robotics Association" personal="https://www.utra.ca" linkedin="https://www.linkedin.com/company/university-of-toronto-robotics-association" facebook="https://www.facebook.com/UTRA.ca" profile_pic="/images/rcgs/utra.png">}}
-{{< profilePic/profilePic  bold=true name="RUCS"  position="Review of Undergraduate Computer Science" personal=" https://rucs.ca" facebook="https://www.facebook.com/RUCSjournal"  profile_pic="/images/rcgs/rucs.png">}}
+{{< profilePic/profilePic  bold=true name="RUCS"  position="Review of Undergraduate Computer Science" facebook="https://www.facebook.com/RUCSjournal"  profile_pic="/images/rcgs/rucs.png">}}
 {{< profilePic/profilePic bold=true name="UTSDSC"  position="U of T Students Digital Society Collective" linkedin="https://www.linkedin.com/company/uoft-digital-society-collective"  profile_pic="/images/rcgs/utsdsc.jpg">}}
 {{< profilePic/profilePic  bold=true name="TURCS"  position="Toronto Undergraduate Research in Computer Science" linkedin="https://www.linkedin.com/company/turcs" facebook="https://www.facebook.com/turcsuoft"  profile_pic="/images/rcgs/turcs.png">}}
 {{< profilePic/profilePic bold=true name="UTWD"  position="U of T Web Dev Club" linkedin="https://www.linkedin.com/company/uoft-web" facebook="https://www.facebook.com/uoftweb"  github="https://github.com/uoftweb" profile_pic="/images/rcgs/utwd.png">}}
-{{< profilePic/profilePic bold=true name="WICS"  position="U of T Women in Computer Science" facebook="https://www.facebook.com/UofTWiCS/" profile_pic="/images/rcgs/wics.png">}}
+{{< profilePic/profilePic bold=true name="WICS"  position="U of T Women in Computer Science" personal="https://uoftwics.netlify.app/" linkedin="https://www.linkedin.com/company/uoftwics/" facebook="https://www.facebook.com/UofTWiCS/" profile_pic="/images/rcgs/wics.png">}}
 
 {{</ profilePic/profilePicContainer >}}
 
@@ -62,11 +61,11 @@ Recognized campus groups (RCGs) are student groups ("clubs") recognized by [**UL
 
 {{< profilePic/profilePic bold=true name="CSSC"  position="Computer Science Student Community" personal="https://cssc.utm.utoronto.ca"  github= "https://github.com/utm-cssc"  profile_pic="/images/rcgs/cssc.png">}}
 
-{{< profilePic/profilePic bold=true name="DSC UTM"  position="Developer Student Club UTM" linkedin="https://www.linkedin.com/company/dscutm"  facebook="https://www.facebook.com/utmdsc"  github="https://github.com/DSC-UTMap" profile_pic="/images/rcgs/dsc_utsg.png">}}
+{{< profilePic/profilePic bold=true name="DSC UTM"  position="Developer Student Club UTM" facebook="https://www.facebook.com/utmdsc"  github="https://github.com/DSC-UTMap" profile_pic="/images/rcgs/dsc_utsg.png">}}
 
-{{< profilePic/profilePic bold=true name="MCSS"  position="Mathematical and Computational Sciences Society" linkedin="https://www.linkedin.com/company/utmmcss/"  facebook="https://www.facebook.com/utmmcss/"  github="https://github.com/DSC-UTMap" profile_pic="/images/rcgs/mcss.png">}}
+{{< profilePic/profilePic bold=true name="MCSS"  position="Mathematical and Computational Sciences Society" linkedin="https://www.linkedin.com/company/utmmcss/"  facebook="https://www.facebook.com/utmmcss/"  github="https://github.com/utmmcss" profile_pic="/images/rcgs/mcss.png">}}
 
-{{< profilePic/profilePic bold=true name="UTMSAM"  position="Society for Algorithmic Modelling" personal="https://utmsam.sa.utoronto.ca/" linkedin="https://www.linkedin.com/company/utmsam2020/"  facebook="https://utmsam.sa.utoronto.ca/"  github="https://github.com/UTM-Society-for-Algorithmic-Modelling" profile_pic="/images/rcgs/utmsam.png">}}
+{{< profilePic/profilePic bold=true name="UTMSAM"  position="Society for Algorithmic Modelling" personal="https://utmsam.sa.utoronto.ca/" linkedin="https://www.linkedin.com/company/utmsam2020/"  facebook="https://www.facebook.com/UTMSAM"  github="https://github.com/UTM-Society-for-Algorithmic-Modelling" profile_pic="/images/rcgs/utmsam.png">}}
 
 {{< profilePic/profilePic bold=true name="UTM Robotics"  linkedin="https://www.linkedin.com/company/utmrobotics/" facebook="https://www.facebook.com/utmrobotics"  github="https://github.com/utmrobotics" profile_pic="/images/rcgs/utmrobotics.png">}}
 


### PR DESCRIPTION
April 6 CSSU Community Page

- Remove ACCS: No longer exists
- UTMSAM Facebook link is just their website---real link: https://www.facebook.com/UTMSAM
- MCSS GitHub link is just DSC UTM's GitHub---real link: https://github.com/utmmcss
- DSC UTM LinkedIn link dead, no replacement
- Add WiCS LinkedIn: https://www.linkedin.com/company/uoftwics/
- Add WiCS personal: https://uoftwics.netlify.app/
- Remove dead RUCS personal, no replacement
- "UTQCC" LinkedIn is just UTMIST's LinkedIn: no replacement
- "UTQCC" actually goes by UTQC: edited to reflect this
- "UTQCC"/UTQC personal link updated to be their SOP page: https://sop.utoronto.ca/group/quantum-computing-club/
- DST GitHub is just UTMIST's GitHub: no replacement
- Add CSSA personal: https://cssa.sa.utoronto.ca/
- Add CSSA LinkedIn (just redirects to the about page either way, so I included that in the link): https://www.linkedin.com/company/uoftcssa/about/
- BCBSU LinkedIn is just CSSU LinkedIn: no replacement