### PR TITLE
[Bug] Fix name parameter issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/update.yml
+++ b/.github/ISSUE_TEMPLATE/update.yml
@@ -1,5 +1,5 @@
 ---
-name: Site issue
+name: Update
 description: "for when content on the site needs to be added or updated"
 title: "[Update] your title goes here"
 assignees: JasonBarahan


### PR DESCRIPTION
The name parameter in the update.yml file wasn't properly updated thus yielding a 'non-unique issue name' error.
This has been fixed in this PR